### PR TITLE
Added Proper Margin-top to Submit of Form Builder

### DIFF
--- a/website/src/components/FormBuilder/FormBuilder.tsx
+++ b/website/src/components/FormBuilder/FormBuilder.tsx
@@ -193,7 +193,7 @@ const FormBuilder: React.FC<FormBuilderProps> = ({
       {formStructure.attrs.map((field, index) => (
         <div key={index}>{renderFormField(field)}</div>
       ))}
-      <button type="submit" className="btn">
+      <button type="submit" className="btn mt-4">
         {buttonText}
       </button>
     </form>


### PR DESCRIPTION
adds `mt-4` to submit button, given 1rem (16px) margin-top to match the other inputs' margins in the form