### PR TITLE
Made changes to Dev Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 		"KAFKA_BROKER_URL": "localhost:9092"
 	},
 	"postCreateCommand": "docker compose up zookeeper kafka mongo --no-start && cd website && npm i",
-	"postStartCommand": "docker start applicantatlas-zookeeper-1 applicantatlas-mongo-1 && echo waiting 20s to start kafka... && sleep 20 && docker start applicantatlas-kafka-1 && cd website && npm run dev",
+	"postStartCommand": "docker start applicantatlas-zookeeper-1 applicantatlas-mongo-1 && echo waiting 20s to start kafka... && sleep 20 && docker start applicantatlas-kafka-1",
 	"portsAttributes": {
 		"3000": {
 			"label": "Website",


### PR DESCRIPTION
The purpose of the dev container is not to have everything up and running the second you open it, that isn't realistic for a dev environment. The purpose is to prepare your dev environment so all a user has to do is open the dev container and run the commands. I would like to believe the functionality is as intended

Reduces time to 20s instead of 30s and added portsAttributes